### PR TITLE
Fixing inconsistent update-plan API calls after cancelling a subscription

### DIFF
--- a/app/routes/dashboard.apps.$appId/view.tsx
+++ b/app/routes/dashboard.apps.$appId/view.tsx
@@ -107,7 +107,7 @@ export default function AppIdLayoutView({
 
     if (!success) return
     if (success === "true") {
-      // update plan type to paid on success
+      // Update plan type to paid on success
       if (
         endpoint &&
         endpoint.appLimits.planType !== PayPlanType.PayAsYouGoV0 &&
@@ -164,7 +164,7 @@ export default function AppIdLayoutView({
   }, [endpoint, t, routes, flags.STRIPE_PAYMENT, subscription])
 
   useEffect(() => {
-    // update plan type to free if plan is paid and there subscription is canceled
+    // Update plan type to free if plan is paid and there subscription is canceled
     if (
       endpoint?.appLimits.planType === PayPlanType.PayAsYouGoV0 &&
       (!subscription || subscription.cancel_at_period_end) &&
@@ -185,10 +185,11 @@ export default function AppIdLayoutView({
   }, [endpoint, subscription, updatePlanFetcher])
 
   useEffect(() => {
-    // update plan type to paid if plan is free and there is a subscription
+    // Update plan type to paid if plan is free and there is a subscription
     if (
       endpoint?.appLimits.planType === PayPlanType.FreetierV0 &&
       subscription &&
+      !subscription.cancel_at_period_end &&
       updatePlanFetcher.state !== "submitting" &&
       updatePlanFetcher.state !== "loading"
     ) {


### PR DESCRIPTION

# Overview

- fixing inconsistent update-plan API calls after cancelling a subscription

Fixing this issue: 
https://www.loom.com/share/af6f2b0ac2924417b40a62e36344874e