### PR TITLE
Fix admin portal broken routes and styles

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -64,10 +64,12 @@ createEmotionCache({ key: "pni" })
 
 export default function App() {
   const { ENV, user } = useLoaderData<RootLoaderData>()
-  const { isDashboard, routes } = useRoot({ user })
+  const { isPlasmic, routes } = useRoot({ user })
   return (
     <>
-      {isDashboard ? (
+      {isPlasmic ? (
+        <PlasmicContainer />
+      ) : (
         <RootProviders>
           <Document>
             <Header user={user}>
@@ -86,8 +88,6 @@ export default function App() {
             />
           </Document>
         </RootProviders>
-      ) : (
-        <PlasmicContainer />
       )}
     </>
   )

--- a/app/root/hooks/useRoot.tsx
+++ b/app/root/hooks/useRoot.tsx
@@ -11,7 +11,11 @@ type useRootProps = { user: Awaited<Auth0Profile | undefined> }
 export const useRoot = ({ user }: useRootProps) => {
   const { t } = useTranslate()
   const { pathname } = useLocation()
-  const isDashboard = useMemo(() => pathname.includes("/dashboard/"), [pathname])
+  const isPlasmic = useMemo(
+    () => !pathname.includes("/dashboard/") && !pathname.includes("/admin"),
+    [pathname],
+  )
+
   useEffect(() => {
     analyticsInit({ id: user?.id ?? "" })
   }, [user])
@@ -56,5 +60,5 @@ export const useRoot = ({ user }: useRootProps) => {
     return allRoutes.filter((r) => r.protected <= protectedLevel)
   }, [t, user])
 
-  return { isDashboard, routes }
+  return { isPlasmic, routes }
 }

--- a/app/routes/admin._index/route.tsx
+++ b/app/routes/admin._index/route.tsx
@@ -1,0 +1,5 @@
+import { LoaderFunction, redirect } from "@remix-run/node"
+
+export const loader: LoaderFunction = async ({ request }) => {
+  return redirect("/admin/users/pay-plan")
+}

--- a/app/routes/admin.settings.feature-flags/route.tsx
+++ b/app/routes/admin.settings.feature-flags/route.tsx
@@ -1,11 +1,17 @@
 import { Button, Checkbox, Container } from "@pokt-foundation/pocket-blocks"
-import { LinksFunction } from "@remix-run/node"
+import { LinksFunction, MetaFunction } from "@remix-run/node"
 import { useFetcher } from "@remix-run/react"
 import Card, { links as CardLinks } from "~/components/Card"
 import CardList, { CardListItem, links as CardListLinks } from "~/components/CardList"
 import { useFeatureFlags } from "~/context/FeatureFlagContext"
 
 export const links: LinksFunction = () => [...CardLinks(), ...CardListLinks()]
+
+export const meta: MetaFunction = () => {
+  return {
+    title: "Feature Flags | Admin",
+  }
+}
 
 export default function FeatureFlags() {
   const fetcher = useFetcher()

--- a/app/routes/admin.users.pay-plan/route.tsx
+++ b/app/routes/admin.users.pay-plan/route.tsx
@@ -1,5 +1,5 @@
 import { Button, Container, Select } from "@pokt-foundation/pocket-blocks"
-import { LinksFunction } from "@remix-run/node"
+import { LinksFunction, MetaFunction } from "@remix-run/node"
 import { useFetcher } from "@remix-run/react"
 import { useState } from "react"
 import Card, { links as CardLinks } from "~/components/Card"
@@ -7,6 +7,12 @@ import TextInput from "~/components/TextInput"
 import { PayPlanType } from "~/models/portal/sdk"
 
 export const links: LinksFunction = () => [...CardLinks()]
+
+export const meta: MetaFunction = () => {
+  return {
+    title: "Custom Pay Plan | Admin",
+  }
+}
 
 export default function CustomPayPlan() {
   const [selectedPlanType, setSelectedPlanType] = useState<string | null>(null)

--- a/app/routes/admin/route.tsx
+++ b/app/routes/admin/route.tsx
@@ -36,11 +36,11 @@ type Route = {
 export default function Admin() {
   const routes: Route[] = [
     {
-      to: "customPayPlan",
+      to: "users/pay-plan",
       label: "Pay Plan",
     },
     {
-      to: "featureflags",
+      to: "settings/feature-flags",
       label: "Feature Flags",
     },
   ]


### PR DESCRIPTION
# Overview

- Fix admin portal broken routes and styles
- Set custom pay plan as default landing route
- Added meta info (title) to the routes

# Evidence

<img width="1720" alt="image" src="https://github.com/pokt-foundation/portal-platform/assets/38038348/e637d6d1-9fb7-4beb-8a72-9e6ad756b025">

<img width="1716" alt="image" src="https://github.com/pokt-foundation/portal-platform/assets/38038348/e6de13ab-c3e3-43dd-aa1b-c0352e89cc0b">
