### PR TITLE
use full auth0 id and not parsed id

### DIFF
--- a/app/routes/dashboard.apps._index/route.tsx
+++ b/app/routes/dashboard.apps._index/route.tsx
@@ -39,7 +39,7 @@ export const loader: LoaderFunction = async ({ request }) => {
   let dailyNetworkRelaysPerWeek: RelayMetric[] | null = null
 
   try {
-    dailyNetworkRelaysPerWeek = await getRelaysPerPeriod("users", 7, userId)
+    dailyNetworkRelaysPerWeek = await getRelaysPerPeriod("users", 7, user.profile.id)
   } catch (e) {}
 
   return json<AppsLoaderData>(


### PR DESCRIPTION
update relay meter to use the full user id instead of the parsed user id. 

example: `auth0|1232546757` vs `1232546757`
