### PR TITLE
use the owner email to find subscription details

### DIFF
--- a/app/routes/dashboard.apps.$appId/route.tsx
+++ b/app/routes/dashboard.apps.$appId/route.tsx
@@ -89,8 +89,9 @@ export const loader: LoaderFunction = async ({ request, params }) => {
   const endpoint = endpointRes?.endpoint
   invariant(endpoint, "app id not found")
 
-  const uEmail = user?.profile?._json?.email ?? ""
-  const subscription = await getSubscription(uEmail, endpoint.id, userId)
+  const ownerEmail =
+    endpoint.users.find((user) => user.userID === endpoint.userId)?.email ?? ""
+  const subscription = await getSubscription(ownerEmail, endpoint.id, userId)
 
   const dailyNetworkRelaysPerWeek = await getRelaysPerPeriod("endpoints", 7, endpoint.id)
   const { blockchains } = await portal.blockchains({ active: true })


### PR DESCRIPTION
- ensure we get stripe subscription details using owner email and not based on team admin/member email addresses. 