### PR TITLE
Dashboard => Homepage Bug

### DIFF
--- a/app/components/Header/Header.tsx
+++ b/app/components/Header/Header.tsx
@@ -112,14 +112,14 @@ export const Header: React.FC<HeaderProps> = ({ user, nav = "left", children }) 
     <>
       <header className="pokt-header">
         <div className="pokt-header-branding pokt-header-flex">
-          <Link to="/">
+          <a href="/">
             <img
               alt="pocket network"
               className="pokt-header-brand"
               loading="lazy"
               src="/pni_portal_logo_blue.svg"
             ></img>
-          </Link>
+          </a>
         </div>
         <HamburgerMenu isActive={isActive} onClick={() => setIsActive(!isActive)} />
         <div

--- a/app/routes/api.auth.auth0/route.tsx
+++ b/app/routes/api.auth.auth0/route.tsx
@@ -11,14 +11,14 @@ export let loader: LoaderFunction = ({ request }) => {
     const signupRequest = new Request(url.toString(), request)
     return authenticator.authenticate("auth0", signupRequest, {
       successRedirect: "/dashboard",
-      failureRedirect: "/",
+      failureRedirect: url.origin,
     })
   }
 
   const loginRequest = new Request(url.toString(), request)
   return authenticator.authenticate("auth0", loginRequest, {
     successRedirect: "/dashboard",
-    failureRedirect: "/",
+    failureRedirect: url.origin,
   })
 }
 
@@ -27,28 +27,28 @@ export let action: ActionFunction = async ({ request }) => {
   const logoutField = formData.get("logout")
   const signupField = formData.get("signup")
 
+  const url = new URL(request.url)
+
   if (logoutField) {
     return authenticator.logout(request, {
-      redirectTo: "/",
+      redirectTo: `${url.origin}`,
     })
   }
 
   if (signupField) {
-    const url = new URL(request.url)
     url.searchParams.append("screen_hint", "signup")
     url.searchParams.append("prompt", "login")
     const signupRequest = new Request(url.toString(), request)
     return authenticator.authenticate("auth0", signupRequest, {
       successRedirect: "/dashboard",
-      failureRedirect: "/",
+      failureRedirect: url.origin,
     })
   }
 
-  const url = new URL(request.url)
   url.searchParams.append("prompt", "login")
   const loginRequest = new Request(url.toString(), request)
   return authenticator.authenticate("auth0", loginRequest, {
     successRedirect: "/dashboard",
-    failureRedirect: "/",
+    failureRedirect: url.origin,
   })
 }

--- a/app/routes/api.auth.auth0/route.tsx
+++ b/app/routes/api.auth.auth0/route.tsx
@@ -31,7 +31,7 @@ export let action: ActionFunction = async ({ request }) => {
 
   if (logoutField) {
     return authenticator.logout(request, {
-      redirectTo: `${url.origin}`,
+      redirectTo: url.origin,
     })
   }
 


### PR DESCRIPTION
change Link to anchor so that it forces plasmic to load through the server and not client side.

--- 

We are seeing an issue where when the user is logged into the dashboard and tries to return to the homepage, plasmic is not loading correctly.

This is most likely due to the fact that the PlasmicProvider does not live on the dashboard and when trying to load the provider from the client side without it we get this error.