### PR TITLE
Team actions follow up

### DIFF
--- a/app/components/AppHeader/AppHeader.tsx
+++ b/app/components/AppHeader/AppHeader.tsx
@@ -1,5 +1,5 @@
 import { Burger, Flex, Group, MediaQuery } from "@pokt-foundation/pocket-blocks"
-import { Link } from "@remix-run/react"
+import { Link, useParams } from "@remix-run/react"
 import OrganizationDrawer from "~/components/OrganizationDrawer"
 import OrganizationSelect from "~/components/OrganizationSelect"
 import { Account, User } from "~/models/portal/sdk"
@@ -19,13 +19,15 @@ export const AppHeader = ({
   accounts,
   hasPendingInvites,
 }: HeaderProps) => {
+  const { accountId } = useParams()
+
   return (
     <>
       <Flex align="center" h="100%" justify="space-between">
         <MediaQuery largerThan="sm" styles={{ display: "none" }}>
           <Burger mr="xl" opened={opened} size="sm" onClick={() => onOpen(!opened)} />
         </MediaQuery>
-        <Link to="/">
+        <Link to={accountId ? `/account/${accountId}` : "/"}>
           <img alt="Grove logo" height={20} loading="lazy" src="/grove-logo.svg"></img>
         </Link>
         <Group>

--- a/app/components/DataTable/DataTableBody.tsx
+++ b/app/components/DataTable/DataTableBody.tsx
@@ -15,12 +15,12 @@ export const DataTableBody = ({ paginatedData, rowAsLink, data }: TableBodyProps
   return (
     <tbody>
       {paginatedData.length > 0 ? (
-        paginatedData.map((item) => {
+        paginatedData.map((item, index) => {
           const { id, ...itemData } = item
           const tableData = Object.entries(itemData)
 
           return (
-            <tr key={id}>
+            <tr key={`${id}-${index}`}>
               {rowAsLink ? (
                 <Link
                   style={{

--- a/app/components/OrganizationSelect/OrganizationSelect.tsx
+++ b/app/components/OrganizationSelect/OrganizationSelect.tsx
@@ -49,7 +49,10 @@ const OrganizationSelect = ({ accounts }: OrganizationSelectProps) => {
   const menuAccounts = useMemo(() => {
     if (activeAccount) {
       const filteredAccounts = accounts.filter(({ id }) => id !== accountId)
-      return [activeAccount, ...filteredAccounts] as Account[]
+      return [
+        activeAccount,
+        ...filteredAccounts.sort((a, b) => (a.id > b.id ? 1 : -1)),
+      ] as Account[]
     }
     return accounts
   }, [accountId, accounts, activeAccount])

--- a/app/hooks/useModals.tsx
+++ b/app/hooks/useModals.tsx
@@ -1,9 +1,15 @@
-import { openConfirmModal, openModal } from "@mantine/modals"
+import {
+  openConfirmModal,
+  openModal,
+  useModals as MantineUseModals,
+} from "@mantine/modals"
 import { ModalSettings, OpenConfirmModal } from "@mantine/modals/lib/context"
 import { useMantineTheme } from "@pokt-foundation/pocket-blocks"
 
 const useModals = () => {
   const theme = useMantineTheme()
+
+  const { modals } = MantineUseModals()
 
   const commonModalProps: ModalSettings = {
     centered: true,
@@ -37,7 +43,12 @@ const useModals = () => {
     })
   }
 
-  return { openConfirmationModal, openContentModal, openFullScreenModal }
+  return {
+    openConfirmationModal,
+    openContentModal,
+    openFullScreenModal,
+    modals,
+  }
 }
 
 export default useModals

--- a/app/routes/account.$accountId.$appId.team/components/InviteMemberForm/InviteMemberFrom.tsx
+++ b/app/routes/account.$accountId.$appId.team/components/InviteMemberForm/InviteMemberFrom.tsx
@@ -82,11 +82,6 @@ const InviteMemberFrom = () => {
                 type="submit"
                 value="true"
                 w="156px"
-                onClick={() =>
-                  setTimeout(() => {
-                    closeAllModals()
-                  }, 1000)
-                }
               >
                 Invite
               </Button>

--- a/app/routes/account.$accountId.$appId.team/components/TeamMemberAction/TeamMemberAction.tsx
+++ b/app/routes/account.$accountId.$appId.team/components/TeamMemberAction/TeamMemberAction.tsx
@@ -1,12 +1,12 @@
 import { ActionIcon, Flex, Menu, Text } from "@pokt-foundation/pocket-blocks"
 import React, { useMemo } from "react"
 import { LuMinusCircle, LuMoreHorizontal, LuSend } from "react-icons/lu"
-import { AccountUserAccess, RoleNameV2, User } from "~/models/portal/sdk"
+import { AccountUserAccess, PortalApp, RoleNameV2, User } from "~/models/portal/sdk"
 import useTeamModals from "~/routes/account.$accountId.$appId.team/hooks/useTeamModals"
 import useCommonStyles from "~/styles/commonStyles"
 
 type TeamMemberActionProps = {
-  appId: string
+  app: PortalApp
   userRole: RoleNameV2 | null
   user?: User
   teamMember: AccountUserAccess & { accepted: boolean; roleName: RoleNameV2 | null }
@@ -15,14 +15,14 @@ type TeamMemberActionProps = {
 
 const TeamMemberAction = ({
   user,
-  appId,
+  app,
   userRole,
   teamMember,
   status,
 }: TeamMemberActionProps) => {
   const { classes: commonClasses } = useCommonStyles()
   const { openRemoveUserModal, openLeaveTeamModal, openResendEmailModal } = useTeamModals(
-    { appId: appId },
+    { app },
   )
 
   const menuItems = useMemo(() => {

--- a/app/routes/account.$accountId.$appId.team/components/TeamMembersTable/TeamMembersTable.tsx
+++ b/app/routes/account.$accountId.$appId.team/components/TeamMembersTable/TeamMembersTable.tsx
@@ -6,7 +6,6 @@ import {
   Select,
   Text,
 } from "@pokt-foundation/pocket-blocks"
-import { LuUser } from "react-icons/lu"
 import { DataTable } from "~/components/DataTable"
 import Identicon from "~/components/Identicon"
 import { PortalApp, RoleName, RoleNameV2, User } from "~/models/portal/sdk"
@@ -21,7 +20,7 @@ type TeamMembersTableProps = {
 }
 
 const TeamMembersTable = ({ app, userRole, user }: TeamMembersTableProps) => {
-  const { openChangeRoleModal } = useTeamModals({ appId: app.id })
+  const { openChangeRoleModal } = useTeamModals({ app })
 
   const teamData = app.users
     .map((user) => ({
@@ -100,7 +99,7 @@ const TeamMembersTable = ({ app, userRole, user }: TeamMembersTableProps) => {
           action: {
             element: roleName !== RoleNameV2.Owner && (
               <TeamMemberAction
-                appId={app.id}
+                app={app}
                 status={accepted}
                 teamMember={teamData[index]}
                 user={user}

--- a/app/routes/account.$accountId.$appId.team/hooks/useTeamModals.tsx
+++ b/app/routes/account.$accountId.$appId.team/hooks/useTeamModals.tsx
@@ -1,18 +1,18 @@
 import { showNotification } from "@mantine/notifications"
 import { Text } from "@pokt-foundation/pocket-blocks"
-import { useFetcher, useParams } from "@remix-run/react"
+import { useFetcher } from "@remix-run/react"
 import { useEffect } from "react"
 import useModals from "~/hooks/useModals"
-import { RoleName } from "~/models/portal/sdk"
+import { PortalApp, RoleName } from "~/models/portal/sdk"
 
 type useTeamModalsProps = {
-  appId: string
+  app: PortalApp
 }
 
-const useTeamModals = ({ appId }: useTeamModalsProps) => {
+const useTeamModals = ({ app }: useTeamModalsProps) => {
   const fetcher = useFetcher()
   const { openConfirmationModal } = useModals()
-  const { accountId } = useParams()
+  const { accountID: accountId, id: appId } = app
 
   useEffect(() => {
     if (!fetcher.data) return

--- a/app/routes/account.$accountId.$appId.team/route.tsx
+++ b/app/routes/account.$accountId.$appId.team/route.tsx
@@ -1,22 +1,22 @@
-import { useActionData } from ".pnpm/react-router@6.11.0_react@18.2.0/node_modules/react-router"
 import { showNotification } from "@mantine/notifications"
-import { ActionFunction, json, LoaderFunction, redirect } from "@remix-run/node"
-import { useCatch, useOutletContext, useRouteLoaderData } from "@remix-run/react"
+import { ActionFunction, json, LoaderFunction } from "@remix-run/node"
+import {
+  useActionData,
+  useCatch,
+  useOutletContext,
+  useRouteLoaderData,
+} from "@remix-run/react"
 import { useEffect } from "react"
 import invariant from "tiny-invariant"
 import { AppIdOutletContext } from "../account.$accountId.$appId/route"
 import TeamView from "./view"
 import ErrorView from "~/components/ErrorView"
 import { initPortalClient } from "~/models/portal/portal.server"
-import { RoleName, RoleNameV2, User } from "~/models/portal/sdk"
+import { RoleNameV2, User } from "~/models/portal/sdk"
 import { AccountIdLoaderData } from "~/routes/account.$accountId/route"
 import { getErrorMessage } from "~/utils/catchError"
 import { LoaderDataStruct } from "~/utils/loader"
-import {
-  sendTeamInviteEmail,
-  sendTeamNewOwnerEmail,
-  sendTeamUserRemovedEmail,
-} from "~/utils/mail.server"
+import { sendTeamInviteEmail, sendTeamUserRemovedEmail } from "~/utils/mail.server"
 import { requireUser } from "~/utils/user.server"
 
 export type TeamLoaderData = {
@@ -186,7 +186,7 @@ export default function Team() {
 
   const { user } = data
 
-  return <TeamView app={app} user={user} userRole={userRole} />
+  return <TeamView actionData={actionData} app={app} user={user} userRole={userRole} />
 }
 
 export const CatchBoundary = () => {

--- a/app/routes/account.$accountId.$appId.team/view.tsx
+++ b/app/routes/account.$accountId.$appId.team/view.tsx
@@ -1,22 +1,40 @@
 import { Divider } from "@mantine/core"
+import { closeModal } from "@mantine/modals"
 import { Box, Button, Flex, Title } from "@pokt-foundation/pocket-blocks"
+import { useEffect } from "react"
 import useModals from "~/hooks/useModals"
 import { PortalApp, RoleNameV2, User } from "~/models/portal/sdk"
 import InviteMemberFrom from "~/routes/account.$accountId.$appId.team/components/InviteMemberForm"
 import TeamMembersTable from "~/routes/account.$accountId.$appId.team/components/TeamMembersTable"
+import { TeamActionData } from "~/routes/account.$accountId.$appId.team/route"
+import { LoaderDataStruct } from "~/utils/loader"
 
 type TeamViewProps = {
+  actionData: LoaderDataStruct<TeamActionData>
   app: PortalApp
   userRole: RoleNameV2
   user: User
 }
 
-function TeamView({ app, userRole, user }: TeamViewProps) {
-  const { openFullScreenModal } = useModals()
+const INVITE_MEMBER_MODAL_ID = "invite-member-modal"
+
+function TeamView({ actionData, app, userRole, user }: TeamViewProps) {
+  const { openFullScreenModal, modals } = useModals()
   const openInviteMemberModal = () =>
     openFullScreenModal({
+      modalId: INVITE_MEMBER_MODAL_ID,
       children: <InviteMemberFrom />,
     })
+
+  useEffect(() => {
+    if (
+      actionData &&
+      modals.length > 0 &&
+      modals.some(({ id }) => id === INVITE_MEMBER_MODAL_ID)
+    ) {
+      closeModal(INVITE_MEMBER_MODAL_ID)
+    }
+  }, [actionData, modals])
 
   return (
     <Box>

--- a/app/routes/user.invited-apps/components/InvitedAppAction/InvitedAppAction.tsx
+++ b/app/routes/user.invited-apps/components/InvitedAppAction/InvitedAppAction.tsx
@@ -2,39 +2,18 @@ import { Menu, Text, ActionIcon, Button, Group } from "@pokt-foundation/pocket-b
 import { Form, Link, useNavigation } from "@remix-run/react"
 import React from "react"
 import { LuArrowUpRight, LuMinusCircle, LuMoreHorizontal } from "react-icons/lu"
-import useModals from "~/hooks/useModals"
-import { PortalApp } from "~/models/portal/sdk"
+import { PortalApp, User } from "~/models/portal/sdk"
+import useTeamModals from "~/routes/account.$accountId.$appId.team/hooks/useTeamModals"
 import useCommonStyles from "~/styles/commonStyles"
 
-type InvitedAppActionProps = { app: PortalApp & { accepted: boolean } }
+type InvitedAppActionProps = { app: PortalApp & { accepted: boolean }; user: User }
 
-const InvitedAppAction = ({ app }: InvitedAppActionProps) => {
+const InvitedAppAction = ({ app, user }: InvitedAppActionProps) => {
   const { classes: commonClasses } = useCommonStyles()
   const navigation = useNavigation()
-  const { openConfirmationModal } = useModals()
-  const { name, accepted } = app
+  const { accepted } = app
 
-  const leaveApp = () => {
-    // fetcher.submit(
-    //     {
-    //       props here...
-    //     },
-    //     {
-    //       method: "POST",
-    //     },
-    // )
-
-    console.log("leaving app...", app.name)
-  }
-
-  const openLeaveAppModal = () =>
-    openConfirmationModal({
-      title: <Text fw={600}>Leave App</Text>,
-      children: <Text>Are you sure you want to leave {name}?</Text>,
-      labels: { cancel: "Cancel", confirm: "Leave" },
-      confirmProps: { color: "red" },
-      onConfirm: () => leaveApp(),
-    })
+  const { openLeaveTeamModal } = useTeamModals({ app })
 
   return (
     <Group grow={!accepted} position="right" spacing="md">
@@ -58,7 +37,7 @@ const InvitedAppAction = ({ app }: InvitedAppActionProps) => {
             </Menu.Item>
             <Menu.Item
               icon={<LuMinusCircle size={18} />}
-              onClick={() => openLeaveAppModal()}
+              onClick={() => openLeaveTeamModal(user.email, user.portalUserID)}
             >
               <Text>Leave</Text>
             </Menu.Item>

--- a/app/routes/user.invited-apps/components/InvitedAppsTable/InvitedAppsTable.tsx
+++ b/app/routes/user.invited-apps/components/InvitedAppsTable/InvitedAppsTable.tsx
@@ -71,7 +71,7 @@ const InvitedAppsTable = ({ apps, user }: InvitedAppsTableProps) => {
             ),
           },
           action: {
-            element: <InvitedAppAction app={app} />,
+            element: <InvitedAppAction app={app} user={user} />,
           },
         }
       })}


### PR DESCRIPTION
# Overview

- Add correct leave action under user profile -> invited apps
- Fix accountId used as undefined due to usage outside of accounts routes
- Close invite member modal upon action completion instead of always closing after one second