### PR TITLE
New sidenav

### DIFF
--- a/app/components/AccountSelect/AccountSelect.tsx
+++ b/app/components/AccountSelect/AccountSelect.tsx
@@ -28,7 +28,7 @@ const AccountItem = ({
     <Identicon
       alt={`${account.id} profile picture`}
       seed={account.id}
-      size={28}
+      size={32}
       type="account"
     />
     {!iconOnly && (

--- a/app/components/Identicon/Identicon.tsx
+++ b/app/components/Identicon/Identicon.tsx
@@ -24,7 +24,7 @@ export const Identicon = ({ seed, type, alt, size = "md", avatar }: IdenticonPro
   return (
     <Avatar
       alt={alt}
-      radius={avatar ? "xl" : "sm"}
+      radius={avatar ? "xl" : 2}
       size={size}
       src={svgURI}
       sx={(theme: MantineTheme) => ({

--- a/app/components/Sidebar/Sidebar.tsx
+++ b/app/components/Sidebar/Sidebar.tsx
@@ -1,22 +1,12 @@
 import { Divider } from "@mantine/core"
-import { Box, MediaQuery, Navbar, ScrollArea } from "@pokt-foundation/pocket-blocks"
-import { Link, useParams } from "@remix-run/react"
+import { Navbar, ScrollArea } from "@pokt-foundation/pocket-blocks"
+import { useParams } from "@remix-run/react"
 import React, { useMemo, useState } from "react"
-import {
-  LuArrowUpCircle,
-  LuBookOpen,
-  LuLifeBuoy,
-  LuLineChart,
-  LuPanelLeft,
-  LuPlus,
-  LuSettings,
-} from "react-icons/lu"
+import { LuPlus } from "react-icons/lu"
 import AccountSelect from "~/components/AccountSelect"
-import GroveLogo from "~/components/GroveLogo"
 import {
   ExternalLink,
   InternalLink,
-  NavButton,
   SidebarApps,
   SidebarNavRoute,
 } from "~/components/Sidebar/components"

--- a/app/components/Sidebar/Sidebar.tsx
+++ b/app/components/Sidebar/Sidebar.tsx
@@ -1,9 +1,10 @@
 import { Divider } from "@mantine/core"
-import { Navbar, ScrollArea } from "@pokt-foundation/pocket-blocks"
-import { useParams } from "@remix-run/react"
-import React, { useMemo, useState } from "react"
+import { Box, Navbar, ScrollArea } from "@pokt-foundation/pocket-blocks"
+import { Link, useParams } from "@remix-run/react"
+import React, { useMemo } from "react"
 import { LuPlus } from "react-icons/lu"
 import AccountSelect from "~/components/AccountSelect"
+import GroveLogo from "~/components/GroveLogo"
 import {
   ExternalLink,
   InternalLink,
@@ -32,7 +33,6 @@ const getStaticRoutes = (
           {
             to: `/account/${activeAccount?.id}/upgrade`,
             label: "Upgrade to Auto-Scale",
-            // icon: LuArrowUpCircle,
             end: true,
           },
         ]
@@ -41,23 +41,19 @@ const getStaticRoutes = (
       {
         to: `/account/${activeAccount?.id}`,
         label: "Insights",
-        // icon: LuLineChart,
         end: true,
       },
       {
         to: `/account/${activeAccount?.id}/settings`,
         label: "Settings",
-        // icon: LuSettings,
       },
       {
         to: DOCS_PATH,
-        // icon: LuBookOpen,
         label: "Documentation",
         external: true,
       },
       {
         to: DISCORD_PATH,
-        // icon: LuLifeBuoy,
         label: "Support",
         external: true,
       },
@@ -68,7 +64,6 @@ const getStaticRoutes = (
 export const Sidebar = ({ account, hidden, userRole, accounts }: SidebarProps) => {
   const { classes: commonClasses } = useCommonStyles()
   const { accountId } = useParams()
-  const [collapsed, setCollapsed] = useState(false)
   const staticRoutes = useMemo(() => {
     return getStaticRoutes(account, userRole)
   }, [account, userRole])
@@ -83,34 +78,27 @@ export const Sidebar = ({ account, hidden, userRole, accounts }: SidebarProps) =
       hiddenBreakpoint="sm"
       p={8}
       pt={18}
-      width={{ base: collapsed ? 60 : 260 }}
+      width={{ base: 260 }}
     >
       <>
-        {/*<Box ml={10}>*/}
-        {/*  <Link to={`/account/${accountId}`}>*/}
-        {/*    <GroveLogo icon={collapsed} />*/}
-        {/*  </Link>*/}
-        {/*</Box>*/}
-        {/*<Divider mb="md" ml={-8} mr={-8} mt="sm" />*/}
-        <AccountSelect accounts={accounts} collapsed={collapsed} />
+        <AccountSelect accounts={accounts} />
         <ScrollArea h="100%" mt="lg">
           {staticRoutes.map((route, index) =>
             route.external ? (
               <Navbar.Section key={`${route.label}-${index}`}>
-                <ExternalLink iconOnly={collapsed} route={route} />
+                <ExternalLink route={route} />
               </Navbar.Section>
             ) : (
               <Navbar.Section key={`${route.label}-${index}`}>
-                <InternalLink iconOnly={collapsed} route={route} />
+                <InternalLink route={route} />
               </Navbar.Section>
             ),
           )}
           <Divider my="lg" />
           <Navbar.Section>
-            {apps && <SidebarApps apps={apps as PortalApp[]} iconOnly={collapsed} />}
+            {apps && <SidebarApps apps={apps as PortalApp[]} />}
             {canCreateApps && (
               <InternalLink
-                iconOnly={collapsed}
                 route={{
                   to: `/account/${accountId}/create`,
                   label: "New Application",
@@ -121,16 +109,11 @@ export const Sidebar = ({ account, hidden, userRole, accounts }: SidebarProps) =
             )}
           </Navbar.Section>
         </ScrollArea>
-        {/*<MediaQuery smallerThan="sm" styles={{ display: "none" }}>*/}
-        {/*  <Navbar.Section>*/}
-        {/*    <NavButton*/}
-        {/*      icon={LuPanelLeft}*/}
-        {/*      iconOnly={collapsed}*/}
-        {/*      label={`${collapsed ? "Expand" : "Collapse"} sidebar`}*/}
-        {/*      onClick={() => setCollapsed(!collapsed)}*/}
-        {/*    />*/}
-        {/*  </Navbar.Section>*/}
-        {/*</MediaQuery>*/}
+        <Box ml={10}>
+          <Link to={`/account/${accountId}`}>
+            <GroveLogo />
+          </Link>
+        </Box>
       </>
     </Navbar>
   )

--- a/app/components/Sidebar/Sidebar.tsx
+++ b/app/components/Sidebar/Sidebar.tsx
@@ -42,7 +42,7 @@ const getStaticRoutes = (
           {
             to: `/account/${activeAccount?.id}/upgrade`,
             label: "Upgrade to Auto-Scale",
-            icon: LuArrowUpCircle,
+            // icon: LuArrowUpCircle,
             end: true,
           },
         ]
@@ -51,23 +51,23 @@ const getStaticRoutes = (
       {
         to: `/account/${activeAccount?.id}`,
         label: "Insights",
-        icon: LuLineChart,
+        // icon: LuLineChart,
         end: true,
       },
       {
         to: `/account/${activeAccount?.id}/settings`,
         label: "Settings",
-        icon: LuSettings,
+        // icon: LuSettings,
       },
       {
         to: DOCS_PATH,
-        icon: LuBookOpen,
+        // icon: LuBookOpen,
         label: "Documentation",
         external: true,
       },
       {
         to: DISCORD_PATH,
-        icon: LuLifeBuoy,
+        // icon: LuLifeBuoy,
         label: "Support",
         external: true,
       },
@@ -93,17 +93,17 @@ export const Sidebar = ({ account, hidden, userRole, accounts }: SidebarProps) =
       hiddenBreakpoint="sm"
       p={8}
       pt={18}
-      width={{ base: collapsed ? 60 : 300 }}
+      width={{ base: collapsed ? 60 : 260 }}
     >
       <>
-        <Box ml={10}>
-          <Link to={`/account/${accountId}`}>
-            <GroveLogo icon={collapsed} />
-          </Link>
-        </Box>
-        <Divider mb="md" ml={-8} mr={-8} mt="sm" />
+        {/*<Box ml={10}>*/}
+        {/*  <Link to={`/account/${accountId}`}>*/}
+        {/*    <GroveLogo icon={collapsed} />*/}
+        {/*  </Link>*/}
+        {/*</Box>*/}
+        {/*<Divider mb="md" ml={-8} mr={-8} mt="sm" />*/}
         <AccountSelect accounts={accounts} collapsed={collapsed} />
-        <ScrollArea h="100%" mt="lg" mx="-xs" px="xs">
+        <ScrollArea h="100%" mt="lg">
           {staticRoutes.map((route, index) =>
             route.external ? (
               <Navbar.Section key={`${route.label}-${index}`}>
@@ -131,16 +131,16 @@ export const Sidebar = ({ account, hidden, userRole, accounts }: SidebarProps) =
             )}
           </Navbar.Section>
         </ScrollArea>
-        <MediaQuery smallerThan="sm" styles={{ display: "none" }}>
-          <Navbar.Section>
-            <NavButton
-              icon={LuPanelLeft}
-              iconOnly={collapsed}
-              label={`${collapsed ? "Expand" : "Collapse"} sidebar`}
-              onClick={() => setCollapsed(!collapsed)}
-            />
-          </Navbar.Section>
-        </MediaQuery>
+        {/*<MediaQuery smallerThan="sm" styles={{ display: "none" }}>*/}
+        {/*  <Navbar.Section>*/}
+        {/*    <NavButton*/}
+        {/*      icon={LuPanelLeft}*/}
+        {/*      iconOnly={collapsed}*/}
+        {/*      label={`${collapsed ? "Expand" : "Collapse"} sidebar`}*/}
+        {/*      onClick={() => setCollapsed(!collapsed)}*/}
+        {/*    />*/}
+        {/*  </Navbar.Section>*/}
+        {/*</MediaQuery>*/}
       </>
     </Navbar>
   )

--- a/app/components/Sidebar/components/SidebarApps.tsx
+++ b/app/components/Sidebar/components/SidebarApps.tsx
@@ -22,11 +22,7 @@ export const SidebarApps = ({ apps, iconOnly }: SidebarAppsProps) => {
   return (
     <Navbar.Section>
       {appsRoutes.map((SidebarNavRoute) => (
-        <InternalLink
-          key={SidebarNavRoute.to}
-          iconOnly={iconOnly}
-          route={SidebarNavRoute}
-        />
+        <InternalLink key={SidebarNavRoute.to} route={SidebarNavRoute} />
       ))}
     </Navbar.Section>
   )

--- a/app/components/Sidebar/components/SidebarNavLinks.tsx
+++ b/app/components/Sidebar/components/SidebarNavLinks.tsx
@@ -2,12 +2,10 @@ import { CSSObject } from "@mantine/core"
 import {
   Anchor,
   Box,
-  Flex,
   Group,
   MantineTheme,
   Text,
   UnstyledButton,
-  Tooltip,
 } from "@pokt-foundation/pocket-blocks"
 import { NavLink } from "@remix-run/react"
 import { Emoji } from "emoji-picker-react"
@@ -46,7 +44,7 @@ const commonLinkStyles = (theme: MantineTheme): CSSObject => ({
 
   "&.active": {
     backgroundColor:
-      theme.colorScheme === "dark" ? "rgba(39, 41, 47, 0.50)" : theme.colors.gray[0],
+      theme.colorScheme === "dark" ? theme.colors.dark[7] : theme.colors.gray[0],
   },
 })
 

--- a/app/components/Sidebar/components/SidebarNavLinks.tsx
+++ b/app/components/Sidebar/components/SidebarNavLinks.tsx
@@ -22,9 +22,7 @@ export type SidebarNavRoute = {
   external?: boolean
 }
 
-export type LinkLabelProps = Pick<SidebarNavRoute, "icon" | "label" | "imgSrc"> & {
-  iconOnly?: boolean
-}
+export type LinkLabelProps = Pick<SidebarNavRoute, "icon" | "label" | "imgSrc">
 
 type LabelIconProps = Pick<LinkLabelProps, "icon" | "imgSrc" | "label">
 
@@ -73,47 +71,16 @@ const LabelIcon = ({ icon: Icon, imgSrc, label }: LabelIconProps) => {
   return Icon ? <Icon size={18} /> : null
 }
 
-const LinkLabel = ({ icon, label, iconOnly, imgSrc }: LinkLabelProps) => (
+const LinkLabel = ({ icon, label, imgSrc }: LinkLabelProps) => (
   <Group>
     <LabelIcon icon={icon} imgSrc={imgSrc} label={label} />
-    {!iconOnly && (
-      <Text truncate w={190}>
-        {label}
-      </Text>
-    )}
+    <Text truncate w={190}>
+      {label}
+    </Text>
   </Group>
 )
 
-// return (
-//   <Flex sx={{ justifyContent: iconOnly ? "center" : "flex-start" }}>
-//     {/*<Tooltip*/}
-//     {/*  withArrow*/}
-//     {/*  withinPortal*/}
-//     {/*  disabled={!iconOnly}*/}
-//     {/*  label={label}*/}
-//     {/*  offset={35}*/}
-//     {/*  position="right"*/}
-//     {/*>*/}
-//     <Group>
-//       <LabelIcon icon={icon} imgSrc={imgSrc} label={label} />
-//       {!iconOnly && (
-//         <Text truncate w={190}>
-//           {label}
-//         </Text>
-//       )}
-//     </Group>
-//     {/*</Tooltip>*/}
-//   </Flex>
-// )
-// }
-
-export const ExternalLink = ({
-  route,
-  iconOnly,
-}: {
-  route: SidebarNavRoute
-  iconOnly?: boolean
-}) => (
+export const ExternalLink = ({ route }: { route: SidebarNavRoute }) => (
   <Anchor
     href={route.to}
     rel="noreferrer"
@@ -121,22 +88,11 @@ export const ExternalLink = ({
     target="_blank"
     variant="text"
   >
-    <LinkLabel
-      icon={route.icon}
-      iconOnly={iconOnly}
-      imgSrc={route.imgSrc}
-      label={route.label}
-    />
+    <LinkLabel icon={route.icon} imgSrc={route.imgSrc} label={route.label} />
   </Anchor>
 )
 
-export const InternalLink = ({
-  route,
-  iconOnly,
-}: {
-  route: SidebarNavRoute
-  iconOnly?: boolean
-}) => (
+export const InternalLink = ({ route }: { route: SidebarNavRoute }) => (
   <Anchor
     component={NavLink}
     end={route.end}
@@ -144,17 +100,12 @@ export const InternalLink = ({
     sx={commonLinkStyles}
     to={route.to}
   >
-    <LinkLabel
-      icon={route.icon}
-      iconOnly={iconOnly}
-      imgSrc={route.imgSrc}
-      label={route.label}
-    />
+    <LinkLabel icon={route.icon} imgSrc={route.imgSrc} label={route.label} />
   </Anchor>
 )
 
-export const NavButton = ({ icon, label, iconOnly, ...rest }: SidebarButtonProps) => (
+export const NavButton = ({ icon, label, ...rest }: SidebarButtonProps) => (
   <UnstyledButton fz="sm" sx={commonLinkStyles} {...rest}>
-    <LinkLabel icon={icon} iconOnly={iconOnly} label={label} />
+    <LinkLabel icon={icon} label={label} />
   </UnstyledButton>
 )

--- a/app/components/Sidebar/components/SidebarNavLinks.tsx
+++ b/app/components/Sidebar/components/SidebarNavLinks.tsx
@@ -35,7 +35,7 @@ type SidebarButtonProps = LinkLabelProps & { onClick?: () => void }
 const commonLinkStyles = (theme: MantineTheme): CSSObject => ({
   display: "block",
   width: "100%",
-  padding: theme.spacing.xs,
+  padding: 8,
   borderRadius: theme.radius.sm,
   color: theme.colorScheme === "dark" ? theme.colors.dark[0] : theme.black,
   "&:hover": {
@@ -46,7 +46,7 @@ const commonLinkStyles = (theme: MantineTheme): CSSObject => ({
 
   "&.active": {
     backgroundColor:
-      theme.colorScheme === "dark" ? theme.colors.dark[7] : theme.colors.gray[0],
+      theme.colorScheme === "dark" ? "rgba(39, 41, 47, 0.50)" : theme.colors.gray[0],
   },
 })
 
@@ -75,29 +75,39 @@ const LabelIcon = ({ icon: Icon, imgSrc, label }: LabelIconProps) => {
   return Icon ? <Icon size={18} /> : null
 }
 
-const LinkLabel = ({ icon, label, iconOnly, imgSrc }: LinkLabelProps) => {
-  return (
-    <Flex sx={{ justifyContent: iconOnly ? "center" : "flex-start" }}>
-      <Tooltip
-        withArrow
-        withinPortal
-        disabled={!iconOnly}
-        label={label}
-        offset={35}
-        position="right"
-      >
-        <Group>
-          <LabelIcon icon={icon} imgSrc={imgSrc} label={label} />
-          {!iconOnly && (
-            <Text truncate w={220}>
-              {label}
-            </Text>
-          )}
-        </Group>
-      </Tooltip>
-    </Flex>
-  )
-}
+const LinkLabel = ({ icon, label, iconOnly, imgSrc }: LinkLabelProps) => (
+  <Group>
+    <LabelIcon icon={icon} imgSrc={imgSrc} label={label} />
+    {!iconOnly && (
+      <Text truncate w={190}>
+        {label}
+      </Text>
+    )}
+  </Group>
+)
+
+// return (
+//   <Flex sx={{ justifyContent: iconOnly ? "center" : "flex-start" }}>
+//     {/*<Tooltip*/}
+//     {/*  withArrow*/}
+//     {/*  withinPortal*/}
+//     {/*  disabled={!iconOnly}*/}
+//     {/*  label={label}*/}
+//     {/*  offset={35}*/}
+//     {/*  position="right"*/}
+//     {/*>*/}
+//     <Group>
+//       <LabelIcon icon={icon} imgSrc={imgSrc} label={label} />
+//       {!iconOnly && (
+//         <Text truncate w={190}>
+//           {label}
+//         </Text>
+//       )}
+//     </Group>
+//     {/*</Tooltip>*/}
+//   </Flex>
+// )
+// }
 
 export const ExternalLink = ({
   route,


### PR DESCRIPTION
# Overview

- Removing icons from sidenav routes
- Small changes to the identicon size and border radius
- Smaller sidenav width
- Removing Grove logo

![image](https://github.com/pokt-foundation/portal-platform/assets/38038348/939c5fde-5278-4cf2-9a3c-7823e10e5710)

